### PR TITLE
Change: Replace Lambda with Method Reference

### DIFF
--- a/pig-latin/src/main/java/PigLatinTranslator.java
+++ b/pig-latin/src/main/java/PigLatinTranslator.java
@@ -16,7 +16,7 @@ class PigLatinTranslator {
 
         var tokenisedPlainText = Arrays.asList(plaintext.split(" "));
         return tokenisedPlainText.stream()
-                .map(word -> encipherWord(word))
+                .map(this::encipherWord)
                 .collect(Collectors.joining(" "));
     }
 


### PR DESCRIPTION
Use syntactic sugar to point to the object instance currently in scope:

this::encipherWord

Good article on this here: https://javarevisited.blogspot.com/2017/08/how-to-convert-lambda-expression-to-method-reference-in-java8-example.html