### PR TITLE
Change: Don't use Objects.equals for primitive types

### DIFF
--- a/hamming/src/main/java/Hamming.java
+++ b/hamming/src/main/java/Hamming.java
@@ -2,8 +2,8 @@ import java.util.Objects;
 
 public class Hamming {
 
-    private String left;
-    private String right;
+    private final String left;
+    private final String right;
 
     public Hamming(String leftStrand, String rightStrand) {
         this.left = leftStrand;
@@ -17,7 +17,7 @@ public class Hamming {
             throw new IllegalArgumentException("right strand must not be empty.");
         }
 
-        if (! Objects.equals(right.length(), left.length())) {
+        if (! (right.length() == left.length())) {
             throw new IllegalArgumentException("leftStrand and rightStrand must be of equal length.");
         }
     }
@@ -28,7 +28,7 @@ public class Hamming {
             return 0;
         } else {
             for (int i = 0; i < left.length(); i++) {
-                if (Objects.equals(right.charAt(i), left.charAt(i))) {
+                if ((right.charAt(i) == left.charAt(i))) {
                     matches++;
                 }
             }

--- a/hamming/src/test/java/HammingTest.java
+++ b/hamming/src/test/java/HammingTest.java
@@ -1,4 +1,3 @@
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -9,38 +8,38 @@ import static org.junit.Assert.assertEquals;
 public class HammingTest {
 
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testNoDistanceBetweenEmptyStrands() {
         assertEquals(0, new Hamming("", "").getHammingDistance());
     }
 
-    @Ignore("Remove to run test")
+//    @Ignore("Remove to run test")
     @Test
     public void testNoDistanceBetweenShortIdenticalStrands() {
         assertEquals(0, new Hamming("A", "A").getHammingDistance());
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testCompleteDistanceInSingleLetterDifferentStrands() {
         assertEquals(1, new Hamming("G", "T").getHammingDistance());
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testDistanceInLongIdenticalStrands() {
         assertEquals(0, new Hamming("GGACTGAAATCTG", "GGACTGAAATCTG").getHammingDistance());
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testDistanceInLongDifferentStrands() {
         assertEquals(9, new Hamming("GGACGGATTCTG", "AGGACGGATTCT").getHammingDistance());
     }
 
-    @Ignore("Remove to run test")
+//    @Ignore("Remove to run test")
     @Test
     public void testValidatesFirstStrandNotLonger() {
         expectedException.expect(IllegalArgumentException.class);
@@ -49,7 +48,7 @@ public class HammingTest {
         new Hamming("AATG", "AAA");
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testValidatesSecondStrandNotLonger() {
         expectedException.expect(IllegalArgumentException.class);
@@ -58,7 +57,7 @@ public class HammingTest {
         new Hamming("ATA", "AGTG");
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testDisallowLeftEmptyStrand() {
         expectedException.expect(IllegalArgumentException.class);
@@ -67,7 +66,7 @@ public class HammingTest {
         new Hamming("", "G");
     }
 
-    @Ignore("Remove to run test")
+//    @Ignore("Remove to run test")
     @Test
     public void testDisallowRightEmptyStrand() {
         expectedException.expect(IllegalArgumentException.class);


### PR DESCRIPTION
Mentor feedback: Objects.equals is an unnecessary operation to compare
primitive types, for e.g. comparing lengths or characters as there is an
additional cost associated with auto boxing.

You can compare int and char using the == operator.

Also added final, as suggested by IDE.